### PR TITLE
Adicionando fix para suportar a linguagem C++ na checagem de plágio

### DIFF
--- a/src/app/controllers/plagiarismController.js
+++ b/src/app/controllers/plagiarismController.js
@@ -92,7 +92,8 @@ class PlagiarismController{
         try{
 			if(users.length){
 				//const languages = classRoon.
-				// Create a client and specify language and moss user id
+                // Create a client and specify language and moss user id
+                if (language == 'cpp') language = 'cc';
                 const client = new MossClient(language, "235246769");
                 let classPath;
                 if(process.env.NODE_ENV==='production'){


### PR DESCRIPTION
Como a moss espera receber cc ao invés de cpp, eu adicionei esse teste no backend e removi do front a necessidade de enviar "cc"